### PR TITLE
Debounce search input to reduce API calls

### DIFF
--- a/anyOf.jst
+++ b/anyOf.jst
@@ -1,0 +1,46 @@
+{{# def.definitions }}
+{{# def.errors }}
+{{# def.setupKeyword }}
+{{# def.setupNextLevel }}
+
+{{
+  var $noEmptySchema = $schema.every(function($sch) {
+    return {{# def.nonEmptySchema:$sch }};
+  });
+}}
+{{? $noEmptySchema }}
+  {{ var $currentBaseId = $it.baseId; }}
+  var {{=$errs}} = errors;
+  var {{=$valid}} = false;
+
+  {{# def.setCompositeRule }}
+
+  {{~ $schema:$sch:$i }}
+    {{
+      $it.schema = $sch;
+      $it.schemaPath = $schemaPath + '[' + $i + ']';
+      $it.errSchemaPath = $errSchemaPath + '/' + $i;
+    }}
+
+    {{# def.insertSubschemaCode }}
+
+    {{=$valid}} = {{=$valid}} || {{=$nextValid}};
+
+    if (!{{=$valid}}) {
+    {{ $closingBraces += '}'; }}
+  {{~}}
+
+  {{# def.resetCompositeRule }}
+
+  {{= $closingBraces }}
+
+  if (!{{=$valid}}) {
+    {{# def.extraError:'anyOf' }}
+  } else {
+    {{# def.resetErrors }}
+  {{? it.opts.allErrors }} } {{?}}
+{{??}}
+  {{? $breakOnError }}
+    if (true) {
+  {{?}}
+{{?}}


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce redundant API requests when users type quickly. This will lower server load and improve perceived responsiveness; implement via lodash.debounce or a small useDebounce hook and add unit test coverage.