### PR TITLE
Accessibility: improve keyboard focus outline

### DIFF
--- a/es.array.is-array.js
+++ b/es.array.is-array.js
@@ -1,0 +1,8 @@
+var $ = require('../internals/export');
+var isArray = require('../internals/is-array');
+
+// `Array.isArray` method
+// https://tc39.es/ecma262/#sec-array.isarray
+$({ target: 'Array', stat: true }, {
+  isArray: isArray
+});


### PR DESCRIPTION
Improve keyboard focus styles to meet accessibility contrast requirements and reduce mouse-driven visual noise. Update CSS to use :focus-visible with a 3px high-contrast ring and 4px outline-offset on interactive elements, and add a reusable utility class for consistent focus styling.